### PR TITLE
signatureが空の場合を許容するように修正

### DIFF
--- a/lib/siteguard_lite/custom_signature/bytesize_validator.rb
+++ b/lib/siteguard_lite/custom_signature/bytesize_validator.rb
@@ -1,6 +1,6 @@
 class BytesizeValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    if value.bytesize > options[:maximum]
+    if value && value.bytesize > options[:maximum]
       record.errors.add(attribute, :too_long, count: options[:maximum])
     end
   end

--- a/spec/siteguard_lite/custom_signature/rule_spec.rb
+++ b/spec/siteguard_lite/custom_signature/rule_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe SiteguardLite::CustomSignature::Rule do
         before { args[:signature] = 'a' * 1000 }
         it { is_expected.to eq false }
       end
+
+      context 'when blank' do
+        before { args[:signature] = nil }
+        it { is_expected.to eq true }
+      end
     end
   end
 end


### PR DESCRIPTION
yamlから設定ファイルを生成する際に、下記パターンのように `signature` が空のパターンが有ると、 `NoMethodError` で落ちてしまいます。
signatureが空でも設定ファイルを正常に出力できるように、問題の箇所にnilチェックを追加致します。

```
---
rules:
- name: hoge
  comment: wp-adminのホワイトリスト（content, newcontentパラメータ）
  exclusion_action:
  signature:
  conditions:
  - key: PATH
    value: "/wp-admin/(admin|admin-ajax|plugin-editor|post|theme-editor)\\.php"
    comparison_methods:
    - PCRE_CASELESS
  - key: PARAM_NAME
    value: "^(content|newcontent)$"
    comparison_methods:
    - PCRE_CASELESS
    - AND
```


```
PMAC368S ~/git/git.pepabo.com/fukuoka-admin/puppetserver(master ✗) bundle exec rake generate:signature_file_for_waf
create sig_custom.txt
rake aborted!
NoMethodError: undefined method `bytesize' for nil:NilClass
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/siteguard_lite-custom_signature-0.3.0/lib/siteguard_lite/custom_signature/bytesize_validator.rb:3:in `validate_each'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activemodel-5.2.1/lib/active_model/validator.rb:152:in `block in validate'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activemodel-5.2.1/lib/active_model/validator.rb:149:in `each'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activemodel-5.2.1/lib/active_model/validator.rb:149:in `validate'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:426:in `block in make_lambda'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:198:in `block (2 levels) in halting'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:606:in `block (2 levels) in default_terminator'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:605:in `catch'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:605:in `block in default_terminator'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:199:in `block in halting'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:513:in `block in invoke_before'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:513:in `each'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:513:in `invoke_before'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:131:in `run_callbacks'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:816:in `_run_validate_callbacks'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activemodel-5.2.1/lib/active_model/validations.rb:409:in `run_validations!'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activemodel-5.2.1/lib/active_model/validations.rb:339:in `valid?'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/activemodel-5.2.1/lib/active_model/validations.rb:385:in `validate!'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/siteguard_lite-custom_signature-0.3.0/lib/siteguard_lite/custom_signature/rule.rb:32:in `to_text'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/siteguard_lite-custom_signature-0.3.0/lib/siteguard_lite/custom_signature/text_dumper.rb:5:in `block in dump'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/siteguard_lite-custom_signature-0.3.0/lib/siteguard_lite/custom_signature/text_dumper.rb:5:in `map'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/siteguard_lite-custom_signature-0.3.0/lib/siteguard_lite/custom_signature/text_dumper.rb:5:in `dump'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/siteguard_lite-custom_signature-0.3.0/lib/siteguard_lite/custom_signature.rb:29:in `dump_text'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/Rakefile:34:in `block (3 levels) in <top (required)>'
/Users/yokoo/git/git.pepabo.com/fukuoka-admin/puppetserver/vendor/bundle/ruby/2.5.0/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
/usr/local/opt/rbenv/versions/2.5.1/bin/bundle:23:in `load'
/usr/local/opt/rbenv/versions/2.5.1/bin/bundle:23:in `<main>'
Tasks: TOP => generate:signature_file_for_waf
(See full trace by running task with --trace)
PMAC368S ~/git/git.pepabo.com/fukuoka-admin/puppetserver(master ✗)
```