### PR TITLE
Support BLOCK and WHITE custom signature

### DIFF
--- a/lib/siteguard_lite/custom_signature/condition.rb
+++ b/lib/siteguard_lite/custom_signature/condition.rb
@@ -20,7 +20,7 @@ module SiteguardLite
 
         [
           rule.enable_str,
-          'NONE',
+          rule.action,
           '',
           rule.name,
           @key,
@@ -42,14 +42,13 @@ module SiteguardLite
       private
 
       def comparison_str(rule, last)
-        if last
-          [
-            @comparison_methods,
-            "#{rule.exclusion_action}(#{rule.signature})"
-          ].flatten.join(',')
-        else
-          @comparison_methods.join(',')
+        str = @comparison_methods.join(',')
+
+        if last && rule.exclusion_action && rule.signature
+          str << ",#{rule.exclusion_action}(#{rule.signature})"
         end
+
+        str
       end
     end
   end

--- a/lib/siteguard_lite/custom_signature/rule.rb
+++ b/lib/siteguard_lite/custom_signature/rule.rb
@@ -3,17 +3,19 @@ module SiteguardLite
     class Rule
       include ActiveModel::Validations
 
-      attr_reader :name, :comment, :enable, :conditions
+      attr_reader :name, :action, :comment, :enable, :conditions
       attr_accessor :exclusion_action, :signature
 
       validates :name, bytesize: { maximum: 29 }
       validates :signature, bytesize: { maximum: 999 }
+      validates :action, inclusion: %w(BLOCK NONE WHITE) # TODO support FILTER action
 
       def initialize(args)
         @name = args[:name]
         @comment = args[:comment]
         @exclusion_action = args[:exclusion_action]
         @signature = args[:signature]
+        @action = args[:action] || 'NONE'
 
         @enable = true
 
@@ -42,6 +44,7 @@ module SiteguardLite
       def to_hash
         {
           name: @name,
+          action: @action,
           comment: @comment,
           exclusion_action: @exclusion_action,
           signature: @signature,

--- a/lib/siteguard_lite/custom_signature/yaml_loader.rb
+++ b/lib/siteguard_lite/custom_signature/yaml_loader.rb
@@ -7,6 +7,7 @@ module SiteguardLite
         y['rules'].each do |r|
           rule = SiteguardLite::CustomSignature::Rule.new(
             name: r['name'],
+            action: r['action'],
             comment: r['comment'],
             exclusion_action: r['exclusion_action'],
             signature: r['signature']

--- a/spec/fixtures/sig_custom.txt
+++ b/spec/fixtures/sig_custom.txt
@@ -1,3 +1,5 @@
+ON	WHITE		white-bar-extension	PATH	PCRE_CASELESS	^.*\.bar$		.barは全て通す
+ON	BLOCK		block-foo-extension	PATH	PCRE_CASELESS	^.*\.foo$		.fooは全てブロックする
 ON	NONE		exclude-for-param-foo	URL	PCRE_CASELESS	^http://example\.com		fooパラメータは全シグネチャを除外する
 ON	NONE		exclude-for-param-foo	PARAM_NAME	PCRE_CASELESS,AND,EXCLUDE_OFFICIAL(^.+$)	^foo$		fooパラメータは全シグネチャを除外する
 ON	NONE		exclude-oscmd-try	URL	PCRE_CASELESS	^http://example\.com		oscmd-try系を除外する

--- a/spec/fixtures/sig_custom.yaml
+++ b/spec/fixtures/sig_custom.yaml
@@ -3,6 +3,22 @@ common_exclusion: &common_exclusion
   signature: "^(xss-onX-(\\d+|[a-z]+)|xss-style-filter|xss-tag-filter)$"
 
 rules:
+  - name: white-bar-extension
+    action: WHITE
+    comment: .barは全て通す
+    conditions:
+      - key: PATH
+        value: "^.*\\.bar"
+        comparison_methods:
+          - PCRE_CASELESS
+  - name: block-foo-extension
+    action: BLOCK
+    comment: .fooは全てブロックする
+    conditions:
+      - key: PATH
+        value: "^.*\\.foo"
+        comparison_methods:
+          - PCRE_CASELESS
   -
     name: exclude-for-param-foo
     comment: fooパラメータは全シグネチャを除外する

--- a/spec/siteguard_lite/custom_signature/rule_spec.rb
+++ b/spec/siteguard_lite/custom_signature/rule_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe SiteguardLite::CustomSignature::Rule do
     let(:args) {
       {
         name: 'signature-name',
+        action: 'NONE',
         comment: 'comment',
         exclusion_action: 'EXCLUDE_OFFICIAL',
         signature: '^.+$',
@@ -20,6 +21,18 @@ RSpec.describe SiteguardLite::CustomSignature::Rule do
 
       context 'when length is 30 characters' do
         before { args[:name] = 'a' * 30 }
+        it { is_expected.to eq false }
+      end
+    end
+
+    describe 'action' do
+      context 'when valid action value' do
+        before { args[:action] = 'BLOCK' }
+        it { is_expected.to eq true }
+      end
+
+      context 'when invalid action value' do
+        before { args[:action] = 'ERROR' }
         it { is_expected.to eq false }
       end
     end

--- a/spec/siteguard_lite/custom_signature_spec.rb
+++ b/spec/siteguard_lite/custom_signature_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SiteguardLite::CustomSignature do
     it 'load yaml format data' do
       rules = SiteguardLite::CustomSignature.load_yaml(yaml)
       expect(rules).to be_kind_of Array
-      expect(rules.length).to eq 5
+      expect(rules.length).to eq 7
     end
   end
 
@@ -23,7 +23,7 @@ RSpec.describe SiteguardLite::CustomSignature do
     it 'load text format data' do
       rules = SiteguardLite::CustomSignature.load_text(text)
       expect(rules).to be_kind_of Array
-      expect(rules.length).to eq 5
+      expect(rules.length).to eq 7
     end
   end
 

--- a/spec/siteguard_lite/text_loader_spec.rb
+++ b/spec/siteguard_lite/text_loader_spec.rb
@@ -1,5 +1,26 @@
 RSpec.describe SiteguardLite::CustomSignature::TextLoader do
   describe '.load_text' do
+    context 'when a rule have no exclude_action' do
+      let(:text) { <<~'EOD'}
+        ON	BLOCK		block-foo-action	PATH	PCRE_CASELESS	^.*\.foo$		.fooはブロックする
+      EOD
+
+      it 'load correctly' do
+        rules = SiteguardLite::CustomSignature::TextLoader.load(text)
+        expect(rules).to be_kind_of Array
+        expect(rules.length).to eq 1
+        expect(rules[0].action).to eq 'BLOCK'
+        expect(rules[0].name).to eq 'block-foo-action'
+        expect(rules[0].comment).to eq '.fooはブロックする'
+        expect(rules[0].enable).to eq true
+        expect(rules[0].exclusion_action).to be_nil
+        expect(rules[0].signature).to be_nil
+        expect(rules[0].conditions.length).to eq 1
+        expect(rules[0].conditions[0].key).to eq 'PATH'
+        expect(rules[0].conditions[0].value).to eq '^.*\.foo$'
+        expect(rules[0].conditions[0].comparison_methods).to eq ['PCRE_CASELESS']
+      end
+    end
     context 'when a rule have one conditions' do
       let(:text) { <<~'EOD'}
         ON	NONE		exclude-traversal-3	PARAM_VALUE	PCRE_CASELESS,EXCLUDE_OFFICIAL(^traversal-3$)	//img\\.example\\.com/etc/		画像URLの一部として/etc/が含まれるときはtraversal-3を除外する


### PR DESCRIPTION
オフィシャルのシグネチャを除外する以外のcustom signatureは、`action`の部分がNONEではなく`BLOCK`や`WHITE`となります。あわせて、`exclusion_action`や`signature`の設定がないため、これらの設定をパースできるようにしました。

具体的な用途としては、Railsアプリの前段に置くようなケースで、`.php`への攻撃やスキャンツールなどをカスタムシグネチャの前段で落すようにして、検知の精度を上げたいです。

バリデーションをもう少し詳しく設定する方法はあるのですが、どこまでやるか悩んでいます。例えば、Ruleクラスを親クラスとして、WHITEやBLOCK、EXCLUSIONなどのサブクラスを作ることもできますが、今回はこれくらいにしておきたいです。