### PR TITLE
actionにFILTERを追加

### DIFF
--- a/lib/siteguard_lite/custom_signature/condition.rb
+++ b/lib/siteguard_lite/custom_signature/condition.rb
@@ -17,12 +17,9 @@ module SiteguardLite
       # [有効・無効]<タブ>[動作]<タブ><タブ>[シグネチャ名]<タブ>[検査対象] <タブ>[比較方法]<タブ> [検査文字列]<タブ><タブ>[コメント]
       def to_text(rule, last: false)
         validate!
-        # actionがFILTERの場合、`FILTER:1800` のように整形する
-        rule.action = add_param_filter_lifetime(rule.action, rule.filter_lifetime) if rule.action == ('FILTER')
-
         [
           rule.enable_str,
-          rule.action,
+          rule.action_str,
           '',
           rule.name,
           @key,
@@ -51,10 +48,6 @@ module SiteguardLite
         end
 
         str
-      end
-
-      def add_param_filter_lifetime(action, filter_lifetime)
-        action + ':' + filter_lifetime.to_s
       end
     end
   end

--- a/lib/siteguard_lite/custom_signature/condition.rb
+++ b/lib/siteguard_lite/custom_signature/condition.rb
@@ -22,7 +22,6 @@ module SiteguardLite
 
         [
           rule.enable_str,
-          # actionがFILTERの場合、`FILTER:1800` のように整形する
           rule.action,
           '',
           rule.name,

--- a/lib/siteguard_lite/custom_signature/condition.rb
+++ b/lib/siteguard_lite/custom_signature/condition.rb
@@ -17,11 +17,13 @@ module SiteguardLite
       # [有効・無効]<タブ>[動作]<タブ><タブ>[シグネチャ名]<タブ>[検査対象] <タブ>[比較方法]<タブ> [検査文字列]<タブ><タブ>[コメント]
       def to_text(rule, last: false)
         validate!
+        # actionがFILTERの場合、`FILTER:1800` のように整形する
+        rule.action = add_param_filter_lifetime(rule.action, rule.filter_lifetime) if rule.action == ('FILTER')
 
         [
           rule.enable_str,
           # actionがFILTERの場合、`FILTER:1800` のように整形する
-          to_action_filter_lifetime(rule.action, rule.filter_lifetime),
+          rule.action,
           '',
           rule.name,
           @key,
@@ -52,8 +54,8 @@ module SiteguardLite
         str
       end
 
-      def to_action_filter_lifetime(action, filter_lifetime)
-        action.include?('FILTER') ? action + ':' + filter_lifetime.to_s : action
+      def add_param_filter_lifetime(action, filter_lifetime)
+        action + ':' + filter_lifetime.to_s
       end
     end
   end

--- a/lib/siteguard_lite/custom_signature/condition.rb
+++ b/lib/siteguard_lite/custom_signature/condition.rb
@@ -20,7 +20,8 @@ module SiteguardLite
 
         [
           rule.enable_str,
-          rule.action,
+          # actionがFILTERの場合、`FILTER:1800` のように整形する
+          to_action_filter_lifetime(rule.action, rule.filter_lifetime),
           '',
           rule.name,
           @key,
@@ -49,6 +50,10 @@ module SiteguardLite
         end
 
         str
+      end
+
+      def to_action_filter_lifetime(action, filter_lifetime)
+        action.include?('FILTER') ? action + ':' + filter_lifetime.to_s : action
       end
     end
   end

--- a/lib/siteguard_lite/custom_signature/rule.rb
+++ b/lib/siteguard_lite/custom_signature/rule.rb
@@ -16,10 +16,11 @@ module SiteguardLite
         @exclusion_action = args[:exclusion_action]
         @signature = args[:signature]
         @action = args[:action] || 'NONE'
-        @filter_lifetime = args[:filter_lifetime] || nil
 
-        if @action == ('FILTER') && @filter_lifetime.nil?
-          @filter_lifetime = 300 # default 300sec
+        if @action == 'FILTER'
+          @filter_lifetime = args[:filter_lifetime] || 300
+        else
+          @filter_lifetime = nil
         end
 
         @enable = true

--- a/lib/siteguard_lite/custom_signature/rule.rb
+++ b/lib/siteguard_lite/custom_signature/rule.rb
@@ -8,7 +8,7 @@ module SiteguardLite
 
       validates :name, bytesize: { maximum: 29 }
       validates :signature, bytesize: { maximum: 999 }
-      validates :action, inclusion: %w(BLOCK NONE WHITE) # TODO support FILTER action
+      validates :action, inclusion: %w(BLOCK NONE WHITE FILTER)
 
       def initialize(args)
         @name = args[:name]

--- a/lib/siteguard_lite/custom_signature/rule.rb
+++ b/lib/siteguard_lite/custom_signature/rule.rb
@@ -8,6 +8,7 @@ module SiteguardLite
 
       validates :name, bytesize: { maximum: 29 }
       validates :signature, bytesize: { maximum: 999 }
+      validates :filter_lifetime, format: { with: /\A\d+\z/ }, allow_nil: true
       validates :action, inclusion: %w(BLOCK NONE WHITE FILTER)
 
       def initialize(args)
@@ -18,7 +19,7 @@ module SiteguardLite
         @action = args[:action] || 'NONE'
 
         if @action == 'FILTER'
-          @filter_lifetime = args[:filter_lifetime] || 300
+          @filter_lifetime = args[:filter_lifetime] || '300'
         else
           @filter_lifetime = nil
         end

--- a/lib/siteguard_lite/custom_signature/rule.rb
+++ b/lib/siteguard_lite/custom_signature/rule.rb
@@ -8,7 +8,7 @@ module SiteguardLite
 
       validates :name, bytesize: { maximum: 29 }
       validates :signature, bytesize: { maximum: 999 }
-      validates :action, inclusion: %w(BLOCK NONE WHITE FILTER)
+      validates :action, format: { with: /BLOCK|NONE|WHITE|FILTER/ }
 
       def initialize(args)
         @name = args[:name]

--- a/lib/siteguard_lite/custom_signature/rule.rb
+++ b/lib/siteguard_lite/custom_signature/rule.rb
@@ -37,6 +37,10 @@ module SiteguardLite
         @enable ? 'ON' : 'OFF'
       end
 
+      def action_str
+        @action == 'FILTER' ? "#{@action}:#{@filter_lifetime}" : @action
+      end
+
       def to_text
         validate!
 

--- a/lib/siteguard_lite/custom_signature/rule.rb
+++ b/lib/siteguard_lite/custom_signature/rule.rb
@@ -4,11 +4,11 @@ module SiteguardLite
       include ActiveModel::Validations
 
       attr_reader :name, :action, :comment, :enable, :conditions
-      attr_accessor :exclusion_action, :signature
+      attr_accessor :exclusion_action, :signature, :action, :filter_lifetime
 
       validates :name, bytesize: { maximum: 29 }
       validates :signature, bytesize: { maximum: 999 }
-      validates :action, format: { with: /BLOCK|NONE|WHITE|FILTER/ }
+      validates :action, inclusion: %w(BLOCK NONE WHITE FILTER)
 
       def initialize(args)
         @name = args[:name]
@@ -16,6 +16,7 @@ module SiteguardLite
         @exclusion_action = args[:exclusion_action]
         @signature = args[:signature]
         @action = args[:action] || 'NONE'
+        @filter_lifetime = args[:filter_lifetime] || '300' # default 300sec
 
         @enable = true
 
@@ -45,11 +46,20 @@ module SiteguardLite
         {
           name: @name,
           action: @action,
+          filter_lifetime: @filter_lifetime,
           comment: @comment,
           exclusion_action: @exclusion_action,
           signature: @signature,
           conditions: @conditions.map { |c| c.to_hash },
         }
+      end
+
+      def to_action_filter(action)
+        action.include?('FILTER') ? 'FILTER' : action
+      end
+
+      def to_filter_lifetime(filter_lifetime)
+        filter_lifetime.include?('FILTER') ? filter_lifetime.delete('FILTER:') : nil
       end
     end
   end

--- a/lib/siteguard_lite/custom_signature/rule.rb
+++ b/lib/siteguard_lite/custom_signature/rule.rb
@@ -3,8 +3,8 @@ module SiteguardLite
     class Rule
       include ActiveModel::Validations
 
-      attr_reader :name, :action, :comment, :enable, :conditions
-      attr_accessor :exclusion_action, :signature, :action, :filter_lifetime
+      attr_reader :name, :comment, :enable, :conditions, :filter_lifetime
+      attr_accessor :action, :exclusion_action, :signature
 
       validates :name, bytesize: { maximum: 29 }
       validates :signature, bytesize: { maximum: 999 }
@@ -16,7 +16,11 @@ module SiteguardLite
         @exclusion_action = args[:exclusion_action]
         @signature = args[:signature]
         @action = args[:action] || 'NONE'
-        @filter_lifetime = args[:filter_lifetime] || '300' # default 300sec
+        @filter_lifetime = args[:filter_lifetime] || nil
+
+        if @action == ('FILTER') && @filter_lifetime.nil?
+          @filter_lifetime = 300 # default 300sec
+        end
 
         @enable = true
 
@@ -52,14 +56,6 @@ module SiteguardLite
           signature: @signature,
           conditions: @conditions.map { |c| c.to_hash },
         }
-      end
-
-      def to_action_filter(action)
-        action.include?('FILTER') ? 'FILTER' : action
-      end
-
-      def to_filter_lifetime(filter_lifetime)
-        filter_lifetime.include?('FILTER') ? filter_lifetime.delete('FILTER:') : nil
       end
     end
   end

--- a/lib/siteguard_lite/custom_signature/text_line_parser.rb
+++ b/lib/siteguard_lite/custom_signature/text_line_parser.rb
@@ -7,8 +7,8 @@ module SiteguardLite
         fields = line.split("\t")
         {
           enable: enable(fields[0]),
-          action: fields[1],
-          filter_lifetime: fields[2],
+          action: parse_action(fields[1]),
+          filter_lifetime: parse_filter_lifetime(fields[1]),
           name: fields[3],
           comment: fields[8],
           exclusion_action: exclusion_action(fields[5]),
@@ -60,6 +60,16 @@ module SiteguardLite
         end
 
         @parsed_comarison_str = result
+      end
+
+      # action FILTER:1800
+      def parse_action(parsed_action)
+        parsed_action.include?('FILTER') ? 'FILTER' : parsed_action
+      end
+
+      # 300 default
+      def parse_filter_lifetime(parsed_action)
+        parsed_action.include?('FILTER') ? parsed_action.delete('FILTER:') : nil
       end
     end
   end

--- a/lib/siteguard_lite/custom_signature/text_line_parser.rb
+++ b/lib/siteguard_lite/custom_signature/text_line_parser.rb
@@ -62,12 +62,10 @@ module SiteguardLite
         @parsed_comarison_str = result
       end
 
-      # action FILTER:1800
       def parse_action(parsed_action)
         parsed_action.include?('FILTER') ? 'FILTER' : parsed_action
       end
 
-      # 300 default
       def parse_filter_lifetime(parsed_action)
         parsed_action.include?('FILTER') ? parsed_action.delete('FILTER:') : nil
       end

--- a/lib/siteguard_lite/custom_signature/text_line_parser.rb
+++ b/lib/siteguard_lite/custom_signature/text_line_parser.rb
@@ -8,6 +8,7 @@ module SiteguardLite
         {
           enable: enable(fields[0]),
           action: fields[1],
+          filter_lifetime: fields[2],
           name: fields[3],
           comment: fields[8],
           exclusion_action: exclusion_action(fields[5]),

--- a/lib/siteguard_lite/custom_signature/text_line_parser.rb
+++ b/lib/siteguard_lite/custom_signature/text_line_parser.rb
@@ -1,6 +1,8 @@
 module SiteguardLite
   module CustomSignature
     class TextLineParser
+      FILTER_ACTION_REGEX = /\AFILTER:(\d+)\z/
+
       # siteguardlite-320-0_nginx.pdf, p.52
       # [有効・無効]<タブ>[動作]<タブ><タブ>[シグネチャ名]<タブ>[検査対象] <タブ>[比較方法]<タブ> [検査文字列]<タブ><タブ>[コメント]
       def parse(line)
@@ -63,11 +65,16 @@ module SiteguardLite
       end
 
       def parse_action(parsed_action)
-        parsed_action.include?('FILTER') ? 'FILTER' : parsed_action
+        case parsed_action
+        when FILTER_ACTION_REGEX
+          'FILTER'
+        else
+          parsed_action
+        end
       end
 
       def parse_filter_lifetime(parsed_action)
-        parsed_action.include?('FILTER') ? parsed_action.delete('FILTER:') : nil
+        parsed_action =~ FILTER_ACTION_REGEX ? $1 : nil
       end
     end
   end

--- a/lib/siteguard_lite/custom_signature/text_loader.rb
+++ b/lib/siteguard_lite/custom_signature/text_loader.rb
@@ -17,6 +17,8 @@ module SiteguardLite
             rule.add_condition(*parsed[:condition].fetch_values(:key, :value, :comparison_methods))
             rule.exclusion_action = parsed[:exclusion_action]
             rule.signature = parsed[:signature]
+            rule.action = rule.to_action_filter(parsed[:action])
+            rule.filter_lifetime = rule.to_filter_lifetime(parsed[:action])
           else
             # This line is a new rule
             rules << rule if rule
@@ -29,6 +31,8 @@ module SiteguardLite
               signature: parsed[:signature],
             )
             rule.add_condition(*parsed[:condition].fetch_values(:key, :value, :comparison_methods))
+            rule.action = rule.to_action_filter(parsed[:action])
+            rule.filter_lifetime = rule.to_filter_lifetime(parsed[:action])
           end
         end
 

--- a/lib/siteguard_lite/custom_signature/text_loader.rb
+++ b/lib/siteguard_lite/custom_signature/text_loader.rb
@@ -17,22 +17,19 @@ module SiteguardLite
             rule.add_condition(*parsed[:condition].fetch_values(:key, :value, :comparison_methods))
             rule.exclusion_action = parsed[:exclusion_action]
             rule.signature = parsed[:signature]
-            rule.action = rule.to_action_filter(parsed[:action])
-            rule.filter_lifetime = rule.to_filter_lifetime(parsed[:action])
           else
             # This line is a new rule
             rules << rule if rule
             rule = Rule.new(
               enable: parsed[:enable],
               action: parsed[:action],
+              filter_lifetime: parsed[:filter_lifetime],
               name: parsed[:name],
               comment: parsed[:comment],
               exclusion_action: parsed[:exclusion_action],
               signature: parsed[:signature],
             )
             rule.add_condition(*parsed[:condition].fetch_values(:key, :value, :comparison_methods))
-            rule.action = rule.to_action_filter(parsed[:action])
-            rule.filter_lifetime = rule.to_filter_lifetime(parsed[:action])
           end
         end
 

--- a/lib/siteguard_lite/custom_signature/version.rb
+++ b/lib/siteguard_lite/custom_signature/version.rb
@@ -1,5 +1,5 @@
 module SiteguardLite
   module CustomSignature
-    VERSION = "0.4.0"
+    VERSION = "0.5.0"
   end
 end

--- a/lib/siteguard_lite/custom_signature/yaml_loader.rb
+++ b/lib/siteguard_lite/custom_signature/yaml_loader.rb
@@ -8,6 +8,7 @@ module SiteguardLite
           rule = SiteguardLite::CustomSignature::Rule.new(
             name: r['name'],
             action: r['action'],
+            filter_lifetime: r['filter_lifetime'],
             comment: r['comment'],
             exclusion_action: r['exclusion_action'],
             signature: r['signature']

--- a/spec/fixtures/sig_custom.txt
+++ b/spec/fixtures/sig_custom.txt
@@ -1,4 +1,4 @@
-ON  FILTER  filter-60sec  URL PCRE_CASELESS,AND,COUNTER(60:30)  .*user\\.test\\.jp/.*
+ON	FILTER  filter-60sec  URL PCRE_CASELESS,AND,COUNTER(60:30)  .*user\\.test\\.jp/.*
 ON	WHITE		white-bar-extension	PATH	PCRE_CASELESS	^.*\.bar$		.barは全て通す
 ON	BLOCK		block-foo-extension	PATH	PCRE_CASELESS	^.*\.foo$		.fooは全てブロックする
 ON	NONE		exclude-for-param-foo	URL	PCRE_CASELESS	^http://example\.com		fooパラメータは全シグネチャを除外する

--- a/spec/fixtures/sig_custom.txt
+++ b/spec/fixtures/sig_custom.txt
@@ -1,4 +1,4 @@
-ON	FILTER		filter-60sec	URL	PCRE_CASELESS,AND,COUNTER(60:30)	.*user\\.test\\.jp/.*		接続拒否時間60秒
+ON	FILTER:1800		filter-60sec	URL	PCRE_CASELESS,AND,COUNTER(60:30)	.*user\.test\.jp/.*		接続拒否時間60秒
 ON	WHITE		white-bar-extension	PATH	PCRE_CASELESS	^.*\.bar$		.barは全て通す
 ON	BLOCK		block-foo-extension	PATH	PCRE_CASELESS	^.*\.foo$		.fooは全てブロックする
 ON	NONE		exclude-for-param-foo	URL	PCRE_CASELESS	^http://example\.com		fooパラメータは全シグネチャを除外する

--- a/spec/fixtures/sig_custom.txt
+++ b/spec/fixtures/sig_custom.txt
@@ -1,3 +1,4 @@
+ON  FILTER  filter-60sec  URL PCRE_CASELESS,AND,COUNTER(60:30)  .*user\\.test\\.jp/.*
 ON	WHITE		white-bar-extension	PATH	PCRE_CASELESS	^.*\.bar$		.barは全て通す
 ON	BLOCK		block-foo-extension	PATH	PCRE_CASELESS	^.*\.foo$		.fooは全てブロックする
 ON	NONE		exclude-for-param-foo	URL	PCRE_CASELESS	^http://example\.com		fooパラメータは全シグネチャを除外する

--- a/spec/fixtures/sig_custom.txt
+++ b/spec/fixtures/sig_custom.txt
@@ -1,4 +1,4 @@
-ON	FILTER		filter-60sec  URL PCRE_CASELESS,AND,COUNTER(60:30)  .*user\\.test\\.jp/.*
+ON	FILTER		filter-60sec	URL	PCRE_CASELESS,AND,COUNTER(60:30)	.*user\\.test\\.jp/.*		接続拒否時間60秒
 ON	WHITE		white-bar-extension	PATH	PCRE_CASELESS	^.*\.bar$		.barは全て通す
 ON	BLOCK		block-foo-extension	PATH	PCRE_CASELESS	^.*\.foo$		.fooは全てブロックする
 ON	NONE		exclude-for-param-foo	URL	PCRE_CASELESS	^http://example\.com		fooパラメータは全シグネチャを除外する

--- a/spec/fixtures/sig_custom.txt
+++ b/spec/fixtures/sig_custom.txt
@@ -1,4 +1,4 @@
-ON	FILTER  filter-60sec  URL PCRE_CASELESS,AND,COUNTER(60:30)  .*user\\.test\\.jp/.*
+ON	FILTER		filter-60sec  URL PCRE_CASELESS,AND,COUNTER(60:30)  .*user\\.test\\.jp/.*
 ON	WHITE		white-bar-extension	PATH	PCRE_CASELESS	^.*\.bar$		.barは全て通す
 ON	BLOCK		block-foo-extension	PATH	PCRE_CASELESS	^.*\.foo$		.fooは全てブロックする
 ON	NONE		exclude-for-param-foo	URL	PCRE_CASELESS	^http://example\.com		fooパラメータは全シグネチャを除外する

--- a/spec/fixtures/sig_custom.yaml
+++ b/spec/fixtures/sig_custom.yaml
@@ -6,6 +6,7 @@ rules:
   - name: filter-60sec
     action: FILTER
     exclusion_action: EXCLUDE_OFFICIAL
+    comment: 接続拒否時間60秒
     conditions:
       - key: URL
         value: ".*user\\.test\\.jp/.*"
@@ -13,6 +14,14 @@ rules:
           - PCRE_CASELESS
           - AND
           - COUNTER(60:30)
+  - name: white-bar-extension
+    action: WHITE
+    comment: .barは全て通す
+    conditions:
+      - key: PATH
+        value: "^.*\\.bar"
+        comparison_methods:
+          - PCRE_CASELESS
   - name: block-foo-extension
     action: BLOCK
     comment: .fooは全てブロックする

--- a/spec/fixtures/sig_custom.yaml
+++ b/spec/fixtures/sig_custom.yaml
@@ -5,11 +5,12 @@ common_exclusion: &common_exclusion
 rules:
   - name: filter-60sec
     action: FILTER
+    filter_lifetime: 1800
     exclusion_action: EXCLUDE_OFFICIAL
     comment: 接続拒否時間60秒
     conditions:
       - key: URL
-        value: ".*user\\.test\\.jp/.*"
+        value: .*user\.test\.jp/.*
         comparison_methods:
           - PCRE_CASELESS
           - AND

--- a/spec/fixtures/sig_custom.yaml
+++ b/spec/fixtures/sig_custom.yaml
@@ -3,14 +3,16 @@ common_exclusion: &common_exclusion
   signature: "^(xss-onX-(\\d+|[a-z]+)|xss-style-filter|xss-tag-filter)$"
 
 rules:
-  - name: white-bar-extension
-    action: WHITE
-    comment: .barは全て通す
+  - name: filter-60sec
+    action: FILTER
+    exclusion_action: EXCLUDE_OFFICIAL
     conditions:
-      - key: PATH
-        value: "^.*\\.bar"
+      - key: URL
+        value: .*user\\.test\\.jp/.*
         comparison_methods:
           - PCRE_CASELESS
+          - AND
+          - COUNTER(60:30)
   - name: block-foo-extension
     action: BLOCK
     comment: .fooは全てブロックする

--- a/spec/fixtures/sig_custom.yaml
+++ b/spec/fixtures/sig_custom.yaml
@@ -8,7 +8,7 @@ rules:
     exclusion_action: EXCLUDE_OFFICIAL
     conditions:
       - key: URL
-        value: .*user\\.test\\.jp/.*
+        value: ".*user\\.test\\.jp/.*"
         comparison_methods:
           - PCRE_CASELESS
           - AND

--- a/spec/siteguard_lite/custom_signature/condition_spec.rb
+++ b/spec/siteguard_lite/custom_signature/condition_spec.rb
@@ -18,4 +18,28 @@ RSpec.describe SiteguardLite::CustomSignature::Condition do
       end
     end
   end
+
+  describe '#to_text' do
+    let(:condition) { SiteguardLite::CustomSignature::Condition.new(key, value, comparison_methods) }
+    let(:key) { 'URL' }
+    let(:comparison_methods) { ['PCRE_CASELESS'] }
+    let(:value) { 'value' }
+
+    context 'when action is FILTER' do
+      let(:rule) { SiteguardLite::CustomSignature::Rule.new(args) }
+      let(:args) {
+        {
+          name: 'signature-name',
+          action: 'FILTER',
+          filter_lifetime: '300',
+          comment: 'comment',
+          exclusion_action: 'EXCLUDE_OFFICIAL',
+          signature: '^.+$',
+        }
+      }
+
+      subject { condition.to_text(rule) }
+      it { is_expected.to match /#{args[:action]}:#{args[:filter_lifetime]}/ }
+    end
+  end
 end

--- a/spec/siteguard_lite/custom_signature/rule_spec.rb
+++ b/spec/siteguard_lite/custom_signature/rule_spec.rb
@@ -53,6 +53,17 @@ RSpec.describe SiteguardLite::CustomSignature::Rule do
         it { is_expected.to eq true }
       end
     end
+
+    describe 'filter_lifetime' do
+      context 'when minus' do
+        before do
+          args[:action] = 'FILTER'
+          args[:filter_lifetime] = '-1'
+        end
+
+        it { is_expected.to eq false }
+      end
+    end
   end
 
   describe 'filter_lifetime' do
@@ -68,12 +79,12 @@ RSpec.describe SiteguardLite::CustomSignature::Rule do
 
       context 'filter_lifetime is not set' do
         before { args[:filter_lifetime] = nil }
-        it { is_expected.to eq 300 }
+        it { is_expected.to eq '300' }
       end
 
       context 'filter_lifetime is set' do
-        before { args[:filter_lifetime] = 500 }
-        it { is_expected.to eq 500 }
+        before { args[:filter_lifetime] = '500' }
+        it { is_expected.to eq '500' }
       end
     end
   end

--- a/spec/siteguard_lite/custom_signature/rule_spec.rb
+++ b/spec/siteguard_lite/custom_signature/rule_spec.rb
@@ -88,4 +88,22 @@ RSpec.describe SiteguardLite::CustomSignature::Rule do
       end
     end
   end
+
+  describe '#action_str' do
+    subject { rule.action_str }
+
+    context 'action is not FILTER' do
+      before { args[:action] = 'BLOCK' }
+      it { is_expected.to eq args[:action] }
+    end
+
+    context 'action is FILTER' do
+      before do
+        args[:action] = 'FILTER'
+        args[:filter_lifetime] = '500'
+      end
+
+      it { is_expected.to eq "#{args[:action]}:#{args[:filter_lifetime]}"}
+    end
+  end
 end

--- a/spec/siteguard_lite/custom_signature/rule_spec.rb
+++ b/spec/siteguard_lite/custom_signature/rule_spec.rb
@@ -1,16 +1,16 @@
 RSpec.describe SiteguardLite::CustomSignature::Rule do
-  describe '.valid?' do
-    let(:rule) { SiteguardLite::CustomSignature::Rule.new(args) }
-    let(:args) {
-      {
-        name: 'signature-name',
-        action: 'NONE',
-        comment: 'comment',
-        exclusion_action: 'EXCLUDE_OFFICIAL',
-        signature: '^.+$',
-      }
+  let(:rule) { SiteguardLite::CustomSignature::Rule.new(args) }
+  let(:args) {
+    {
+      name: 'signature-name',
+      action: 'NONE',
+      comment: 'comment',
+      exclusion_action: 'EXCLUDE_OFFICIAL',
+      signature: '^.+$',
     }
+  }
 
+  describe '.valid?' do
     subject { rule.valid? }
 
     describe 'name' do
@@ -51,6 +51,29 @@ RSpec.describe SiteguardLite::CustomSignature::Rule do
       context 'when blank' do
         before { args[:signature] = nil }
         it { is_expected.to eq true }
+      end
+    end
+  end
+
+  describe 'filter_lifetime' do
+    subject { rule.filter_lifetime }
+
+    context 'action is not FILTER' do
+      before { args[:action] = 'BLOCK' }
+      it { is_expected.to be_nil }
+    end
+
+    context 'action is FILTER' do
+      before { args[:action] = 'FILTER' }
+
+      context 'filter_lifetime is not set' do
+        before { args[:filter_lifetime] = nil }
+        it { is_expected.to eq 300 }
+      end
+
+      context 'filter_lifetime is set' do
+        before { args[:filter_lifetime] = 500 }
+        it { is_expected.to eq 500 }
       end
     end
   end

--- a/spec/siteguard_lite/custom_signature_spec.rb
+++ b/spec/siteguard_lite/custom_signature_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SiteguardLite::CustomSignature do
     it 'load yaml format data' do
       rules = SiteguardLite::CustomSignature.load_yaml(yaml)
       expect(rules).to be_kind_of Array
-      expect(rules.length).to eq 7
+      expect(rules.length).to eq 8
     end
   end
 
@@ -23,7 +23,7 @@ RSpec.describe SiteguardLite::CustomSignature do
     it 'load text format data' do
       rules = SiteguardLite::CustomSignature.load_text(text)
       expect(rules).to be_kind_of Array
-      expect(rules.length).to eq 7
+      expect(rules.length).to eq 8
     end
   end
 

--- a/spec/siteguard_lite/text_loader_spec.rb
+++ b/spec/siteguard_lite/text_loader_spec.rb
@@ -66,5 +66,27 @@ RSpec.describe SiteguardLite::CustomSignature::TextLoader do
         expect(rules[0].conditions[1].comparison_methods).to eq ['PCRE_CASELESS', 'AND']
       end
     end
+    context 'when a rule have qfiliter_lifetime' do
+      let(:text) { <<~'EOD'}
+        ON	FILTER:1800		filter-60sec	URL	PCRE_CASELESS,AND,COUNTER(60:30)	.*user\.test\.jp/.*		接続拒否時間60秒
+      EOD
+
+      it 'load correctly' do
+        rules = SiteguardLite::CustomSignature::TextLoader.load(text)
+        expect(rules).to be_kind_of Array
+        expect(rules.length).to eq 1
+        expect(rules[0].action).to eq 'FILTER'
+        expect(rules[0].filter_lifetime).to eq '1800'
+        expect(rules[0].name).to eq 'filter-60sec'
+        expect(rules[0].comment).to eq '接続拒否時間60秒'
+        expect(rules[0].enable).to eq true
+        expect(rules[0].exclusion_action).to be_nil
+        expect(rules[0].signature).to be_nil
+        expect(rules[0].conditions.length).to eq 1
+        expect(rules[0].conditions[0].key).to eq 'URL'
+        expect(rules[0].conditions[0].value).to eq '.*user\.test\.jp/.*'
+        expect(rules[0].conditions[0].comparison_methods).to eq ['PCRE_CASELESS', 'AND', 'COUNTER(60:30)']
+      end
+    end
   end
 end


### PR DESCRIPTION
sig_custom.yml に設定するActionについて、
```
validates :action, inclusion: %w(BLOCK NONE WHITE) # TODO support FILTER action
```
とあり、`FILTER` が指定出来ない状態だったので追加します。