### PR TITLE
VERSIONを最新のtagに合わせ0.6.0に設定

### DIFF
--- a/lib/siteguard_lite/custom_signature/version.rb
+++ b/lib/siteguard_lite/custom_signature/version.rb
@@ -1,5 +1,5 @@
 module SiteguardLite
   module CustomSignature
-    VERSION = "0.5.0"
+    VERSION = "0.6.0"
   end
 end


### PR DESCRIPTION
最新のバージョン `v0.6.0` に合わせて、`version.rb` を更新します。
https://github.com/pepabo/siteguard_lite-custom_signature/releases/tag/v0.6.0

`v0.6.0`の修正内容
https://github.com/pepabo/siteguard_lite-custom_signature/pull/9